### PR TITLE
refactor(api): mejorar endpoint de categorías con orden, paginación y…

### DIFF
--- a/src/categorias/categorias.controller.ts
+++ b/src/categorias/categorias.controller.ts
@@ -51,7 +51,7 @@ export class CategoriasController {
     type: CategoriasNotFoundResponseDto,
   })
   @Get()
-  getAll(@Query() queries: CategoriaQueries): Promise<Categoria[]> {
+  getAll(@Query() queries: CategoriaQueries) {
     return this.categoriasService.findCategorias(queries);
   }
 

--- a/src/categorias/categorias.controller.ts
+++ b/src/categorias/categorias.controller.ts
@@ -18,8 +18,13 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
   CategoriaConflictResponseDto,
   CategoriaNotFoundResponseDto,
+  CategoriasLimitBadRequestResponseDto,
   CategoriasNotFoundResponseDto,
+  CategoriasOffsetBadRequestResponseDto,
+  CategoriasOrderBadRequestResponseDto,
+  CategoriasTitleBadRequestResponseDto,
   DeleteCategoriaResponseDto,
+  ResponseCategoriasDto,
 } from './dto/responses-dto';
 import {
   DeleteResultResponseDto,
@@ -42,16 +47,41 @@ export class CategoriasController {
   @ApiResponse({
     status: 200,
     description: 'Las categorias fueron encontradas exitosamente',
-    type: [Categoria],
+    type: ResponseCategoriasDto,
   })
-  //Para revisar
   @ApiResponse({
     status: 404,
     description: 'Categorias no encontradas',
     type: CategoriasNotFoundResponseDto,
   })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid limit value',
+    type: CategoriasLimitBadRequestResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid offset value',
+    type: CategoriasOffsetBadRequestResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid order value',
+    type: CategoriasOrderBadRequestResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid title value',
+    type: CategoriasTitleBadRequestResponseDto,
+  })
   @Get()
   getAll(@Query() queries: CategoriaQueries) {
+    if (queries.offset) {
+      queries.offset = parseInt(queries.offset as unknown as string, 10);
+    }
+    if (queries.limit) {
+      queries.limit = parseInt(queries.limit as unknown as string, 10);
+    }
     return this.categoriasService.findCategorias(queries);
   }
 

--- a/src/categorias/categorias.service.ts
+++ b/src/categorias/categorias.service.ts
@@ -1,5 +1,5 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { Like, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Categoria } from './categoria.entity';
@@ -18,46 +18,97 @@ export class CategoriasService {
   ) {}
 
   /**
-   * Encuentra todas las categorias
-   * @param urlQueries Queries de la URL
-   * @returns Lista de categorias
+   * Busca y devuelve una lista de categorías según los parámetros de consulta proporcionados.
+   *
+   * @param urlQueries - Objeto que contiene los parámetros de consulta para filtrar y ordenar las categorías.
+   *   - `limit` (opcional): Número máximo de categorías a devolver. Debe ser un número positivo.
+   *   - `withgames` (opcional): Indica si se deben incluir los videojuegos relacionados con las categorías.
+   *     Puede ser un booleano o una cadena que evalúe a "true" o "false".
+   *   - `offset` (opcional): Número de páginas a omitir según el límite especificado. Debe ser un número no negativo.
+   *   - `order` (opcional): Orden de los resultados, ya sea "ASC" (ascendente) o "DESC" (descendente).
+   *   - `title` (opcional): Filtro para buscar categorías cuyo título coincida parcialmente con el valor proporcionado.
+   *
+   * @returns Un objeto que contiene:
+   *   - `data`: Lista de categorías que cumplen con los criterios de búsqueda.
+   *   - `offset`: El valor de desplazamiento utilizado en la consulta.
+   *   - `total`: El número total de categorías que cumplen con los criterios de búsqueda.
+   *
+   * @throws `HttpException`:
+   *   - Si el valor de `limit` no es un número positivo.
+   *   - Si el valor de `offset` no es un número no negativo.
+   *   - Si el valor de `order` no es "ASC" ni "DESC".
+   *   - Si el valor de `title` no es una cadena.
    */
   async findCategorias(urlQueries: CategoriaQueries) {
     const {
       limit = null,
-      withGames = false,
+      withgames = false,
       offset = 0,
       order = 'ASC',
       ...queries
     } = urlQueries;
 
-    if (queries.title) {
-      queries.title = Like(`%${queries.title}%`);
+    const isWithGames =
+      typeof withgames === 'string' ? withgames === 'true' : withgames;
+
+    if (limit !== null && (typeof limit !== 'number' || limit <= 0)) {
+      throw new HttpException('Invalid limit value', HttpStatus.BAD_REQUEST);
+    }
+
+    if (offset < 0 || typeof offset !== 'number') {
+      throw new HttpException('Invalid offset value', HttpStatus.BAD_REQUEST);
+    }
+
+    if (order !== 'ASC' && order !== 'DESC') {
+      throw new HttpException('Invalid order value', HttpStatus.BAD_REQUEST);
+    }
+
+    if (queries.title && typeof queries.title !== 'string') {
+      throw new HttpException('Invalid title value', HttpStatus.BAD_REQUEST);
     }
 
     const queriesResult = this.categoriasRepository
       .createQueryBuilder('categoria')
-      .where(queries)
-      .skip(offset)
-      .take(limit)
       .addOrderBy('categoria.titulo', order);
 
-    if (withGames) {
+    if (isWithGames) {
       queriesResult
         .leftJoinAndSelect('categoria.videoGames', 'videoGames')
         .leftJoinAndSelect('videoGames.thumb', 'thumb')
         .leftJoinAndSelect('videoGames.hero', 'hero')
         .leftJoinAndSelect('videoGames.descuentos', 'descuentos')
         .leftJoinAndSelect('videoGames.assets', 'assets')
-        .addOrderBy('descuentos.fechaInicio', 'ASC')
-        .addOrderBy('descuentos.fechaFin', 'ASC')
-        .addOrderBy('assets.index', 'ASC')
-        .andWhere('descuentos.fechaInicio <= CURRENT_DATE()')
-        .andWhere('descuentos.fechaFin >= CURRENT_DATE()');
+        .addOrderBy('videoGames.titulo', order);
+    }
+
+    if (queries.title) {
+      queriesResult.andWhere('categoria.titulo ILIKE :title', {
+        title: `%${queries.title}%`,
+      });
+    }
+
+    if (limit !== null) {
+      queriesResult.take(limit).skip(offset * limit);
+    }
+
+    const categorias = await queriesResult.getMany();
+
+    if (isWithGames) {
+      categorias.forEach((categoria) => {
+        categoria.videoGames.forEach((videoGame) => {
+          videoGame.descuentos = videoGame.descuentos.filter((descuento) => {
+            const now = new Date();
+            return (
+              new Date(descuento.fechaInicio) <= now &&
+              new Date(descuento.fechaFin) >= now
+            );
+          });
+        });
+      });
     }
 
     return {
-      items: await queriesResult.getMany(),
+      data: categorias,
       offset: offset,
       total: await queriesResult.getCount(),
     };

--- a/src/categorias/categorias.service.ts
+++ b/src/categorias/categorias.service.ts
@@ -22,7 +22,7 @@ export class CategoriasService {
    *
    * @param urlQueries - Objeto que contiene los parámetros de consulta para filtrar y ordenar las categorías.
    *   - `limit` (opcional): Número máximo de categorías a devolver. Debe ser un número positivo.
-   *   - `withgames` (opcional): Indica si se deben incluir los videojuegos relacionados con las categorías.
+   *   - `withGames` (opcional): Indica si se deben incluir los videojuegos relacionados con las categorías.
    *     Puede ser un booleano o una cadena que evalúe a "true" o "false".
    *   - `offset` (opcional): Número de páginas a omitir según el límite especificado. Debe ser un número no negativo.
    *   - `order` (opcional): Orden de los resultados, ya sea "ASC" (ascendente) o "DESC" (descendente).
@@ -42,14 +42,14 @@ export class CategoriasService {
   async findCategorias(urlQueries: CategoriaQueries) {
     const {
       limit = null,
-      withgames = false,
+      withGames = false,
       offset = 0,
       order = 'ASC',
       ...queries
     } = urlQueries;
 
     const isWithGames =
-      typeof withgames === 'string' ? withgames === 'true' : withgames;
+      typeof withGames === 'string' ? withGames === 'true' : withGames;
 
     if (limit !== null && (typeof limit !== 'number' || limit <= 0)) {
       throw new HttpException('Invalid limit value', HttpStatus.BAD_REQUEST);

--- a/src/categorias/categorias.service.ts
+++ b/src/categorias/categorias.service.ts
@@ -23,25 +23,44 @@ export class CategoriasService {
    * @returns Lista de categorias
    */
   async findCategorias(urlQueries: CategoriaQueries) {
-    const { limit, ...queries } = urlQueries;
+    const {
+      limit = null,
+      withGames = false,
+      offset = 0,
+      order = 'ASC',
+      ...queries
+    } = urlQueries;
 
     if (queries.title) {
       queries.title = Like(`%${queries.title}%`);
     }
 
-    return this.categoriasRepository
+    const queriesResult = this.categoriasRepository
       .createQueryBuilder('categoria')
-      .leftJoinAndSelect('categoria.videoGames', 'videoGames')
-      .leftJoinAndSelect('videoGames.thumb', 'thumb')
-      .leftJoinAndSelect('videoGames.hero', 'hero')
-      .leftJoinAndSelect('videoGames.descuentos', 'descuentos')
       .where(queries)
+      .skip(offset)
       .take(limit)
-      .addOrderBy('descuentos.fechaInicio', 'ASC')
-      .addOrderBy('descuentos.fechaFin', 'ASC')
-      .addOrderBy('asset.index', 'ASC')
-      .addOrderBy('categoria.titulo', 'ASC')
-      .getMany();
+      .addOrderBy('categoria.titulo', order);
+
+    if (withGames) {
+      queriesResult
+        .leftJoinAndSelect('categoria.videoGames', 'videoGames')
+        .leftJoinAndSelect('videoGames.thumb', 'thumb')
+        .leftJoinAndSelect('videoGames.hero', 'hero')
+        .leftJoinAndSelect('videoGames.descuentos', 'descuentos')
+        .leftJoinAndSelect('videoGames.assets', 'assets')
+        .addOrderBy('descuentos.fechaInicio', 'ASC')
+        .addOrderBy('descuentos.fechaFin', 'ASC')
+        .addOrderBy('assets.index', 'ASC')
+        .andWhere('descuentos.fechaInicio <= CURRENT_DATE()')
+        .andWhere('descuentos.fechaFin >= CURRENT_DATE()');
+    }
+
+    return {
+      items: await queriesResult.getMany(),
+      offset: offset,
+      total: await queriesResult.getCount(),
+    };
   }
 
   /**

--- a/src/categorias/dto/categoria-queries.dto.ts
+++ b/src/categorias/dto/categoria-queries.dto.ts
@@ -12,7 +12,7 @@ export class CategoriaQueries {
   @IsOptional()
   title?: string | FindOperator<string>;
 
-  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 0 })
+  @IsNumber({ allowInfinity: false, maxDecimalPlaces: 0 })
   @IsOptional()
   limit?: number;
 
@@ -21,11 +21,11 @@ export class CategoriaQueries {
   @IsIn(['ASC', 'DESC'])
   order?: 'ASC' | 'DESC';
 
-  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 0 })
+  @IsNumber({ allowInfinity: false, maxDecimalPlaces: 0 })
   @IsOptional()
   offset?: number;
 
   @IsOptional()
   @IsBoolean()
-  withGames?: boolean;
+  withgames?: boolean;
 }

--- a/src/categorias/dto/categoria-queries.dto.ts
+++ b/src/categorias/dto/categoria-queries.dto.ts
@@ -1,4 +1,10 @@
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { FindOperator } from 'typeorm';
 
 export class CategoriaQueries {
@@ -6,7 +12,20 @@ export class CategoriaQueries {
   @IsOptional()
   title?: string | FindOperator<string>;
 
-  @IsNumber()
+  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 0 })
   @IsOptional()
   limit?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['ASC', 'DESC'])
+  order?: 'ASC' | 'DESC';
+
+  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 0 })
+  @IsOptional()
+  offset?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  withGames?: boolean;
 }

--- a/src/categorias/dto/categoria-queries.dto.ts
+++ b/src/categorias/dto/categoria-queries.dto.ts
@@ -27,5 +27,5 @@ export class CategoriaQueries {
 
   @IsOptional()
   @IsBoolean()
-  withgames?: boolean;
+  withGames?: boolean;
 }

--- a/src/categorias/dto/responses-dto.ts
+++ b/src/categorias/dto/responses-dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Categoria } from '../categoria.entity';
 
 export class CategoriasNotFoundResponseDto {
   @ApiProperty({
@@ -7,6 +8,50 @@ export class CategoriasNotFoundResponseDto {
   statusCode: number;
   @ApiProperty({
     example: 'Las categorias no fueron encontradas',
+  })
+  message: string;
+}
+
+export class CategoriasLimitBadRequestResponseDto {
+  @ApiProperty({
+    example: 400,
+  })
+  statusCode: number;
+  @ApiProperty({
+    example: 'Invalid limit value',
+  })
+  message: string;
+}
+
+export class CategoriasOffsetBadRequestResponseDto {
+  @ApiProperty({
+    example: 400,
+  })
+  statusCode: number;
+  @ApiProperty({
+    example: 'Invalid offset value',
+  })
+  message: string;
+}
+
+export class CategoriasOrderBadRequestResponseDto {
+  @ApiProperty({
+    example: 400,
+  })
+  statusCode: number;
+  @ApiProperty({
+    example: 'Invalid order value',
+  })
+  message: string;
+}
+
+export class CategoriasTitleBadRequestResponseDto {
+  @ApiProperty({
+    example: 400,
+  })
+  statusCode: number;
+  @ApiProperty({
+    example: 'Invalid title value',
   })
   message: string;
 }
@@ -42,4 +87,22 @@ export class DeleteCategoriaResponseDto {
     example: 'Categoria was not deleted',
   })
   message: string;
+}
+export class ResponseCategoriasDto {
+  @ApiProperty({
+    type: [Categoria],
+  })
+  data: Categoria[];
+  @ApiProperty({
+    example: 0,
+  })
+  offset: number;
+  @ApiProperty({
+    example: 10,
+  })
+  limit: number;
+  @ApiProperty({
+    example: 100,
+  })
+  total: number;
 }


### PR DESCRIPTION
refactor(api): mejorar endpoint de categorías con orden, paginación y juegos asociados

- Se agrega soporte para ordenar categorías por título con `order` (ASC/DESC).
- Se implementa paginación con `offset` y `limit`.
- Se añade la opción `withGames` para incluir juegos asociados, ordenados alfabéticamente.
- Se mejora la estructura de respuesta incluyendo el total de elementos.
- Se gestionan errores con el uso  de query params.