### PR TITLE
feat(noticias): refactor endpoint to support sorting, pagination, and…

### DIFF
--- a/src/config/enums/order.enum.ts
+++ b/src/config/enums/order.enum.ts
@@ -1,0 +1,4 @@
+export enum Order {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}

--- a/src/config/enums/orderby.enum.ts
+++ b/src/config/enums/orderby.enum.ts
@@ -1,0 +1,4 @@
+export enum OrderBy {
+  TITLE = 'titulo',
+  DATE = 'fecha',
+}

--- a/src/migrations/1743130090293-fix_relation_between_notices_and_assets.ts
+++ b/src/migrations/1743130090293-fix_relation_between_notices_and_assets.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixRelationBetweenNoticesAndAssets1743130090293
+  implements MigrationInterface
+{
+  name = 'FixRelationBetweenNoticesAndAssets1743130090293';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "noticias" DROP CONSTRAINT "FK_d3a0a482571b98cfda2eb37bdb8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "noticias" ADD CONSTRAINT "FK_d3a0a482571b98cfda2eb37bdb8" FOREIGN KEY ("noticiaThumb") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "noticias" DROP CONSTRAINT "FK_d3a0a482571b98cfda2eb37bdb8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "noticias" ADD CONSTRAINT "FK_d3a0a482571b98cfda2eb37bdb8" FOREIGN KEY ("noticiaThumb") REFERENCES "noticias"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/noticias/dto/queries-notices.dto.ts
+++ b/src/noticias/dto/queries-notices.dto.ts
@@ -1,15 +1,13 @@
-import { IsOptional, IsIn, IsInt, Min, IsNumber } from 'class-validator';
+import { IsOptional, IsInt, Min, IsNumber } from 'class-validator';
+import { Order } from 'src/config/enums/order.enum';
+import { OrderBy } from 'src/config/enums/orderby.enum';
 
 export class QueriesNoticesDto {
   @IsOptional()
-  @IsIn(['ASC', 'DESC'], { message: 'Order must be either ASC or DESC' })
-  order?: 'ASC' | 'DESC' = 'ASC';
+  order?: Order = Order.ASC;
 
   @IsOptional()
-  @IsIn(['titulo', 'fecha'], {
-    message: 'OrderBy must be either titulo or fecha',
-  })
-  orderBy?: 'titulo' | 'fecha' = 'titulo';
+  orderBy?: OrderBy = OrderBy.TITLE;
 
   @IsOptional()
   @IsNumber()

--- a/src/noticias/dto/queries-notices.dto.ts
+++ b/src/noticias/dto/queries-notices.dto.ts
@@ -1,0 +1,30 @@
+import { IsOptional, IsIn, IsInt, Min, IsNumber } from 'class-validator';
+
+export class QueriesNoticesDto {
+  @IsOptional()
+  @IsIn(['ASC', 'DESC'], { message: 'Order must be either ASC or DESC' })
+  order?: 'ASC' | 'DESC' = 'ASC';
+
+  @IsOptional()
+  @IsIn(['titulo', 'fecha'], {
+    message: 'OrderBy must be either titulo or fecha',
+  })
+  orderBy?: 'titulo' | 'fecha' = 'titulo';
+
+  @IsOptional()
+  @IsNumber()
+  @IsInt({ message: 'Offset must be an integer' })
+  @Min(0, { message: 'Offset must be at least 0' })
+  offset?: number = 0;
+
+  @IsOptional()
+  @IsNumber()
+  @IsInt({ message: 'Limit must be an integer' })
+  @Min(1, { message: 'Limit must be at least 1' })
+  limit?: number = null;
+
+  @IsOptional()
+  @IsNumber()
+  @IsInt({ message: 'Author must be an integer' })
+  autor?: number;
+}

--- a/src/noticias/dto/responses-dto.ts
+++ b/src/noticias/dto/responses-dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Noticia } from '../noticia.entity';
 
 export class NoticiasNotFoundResponseDto {
   @ApiProperty({
@@ -20,4 +21,21 @@ export class NoticiaNotFoundResponseDto {
     example: 'Noticia not found',
   })
   message: string;
+}
+
+export class NoticiaFoundResponseDto {
+  @ApiProperty({
+    example: Noticia,
+  })
+  data: Noticia;
+
+  @ApiProperty({
+    example: '2',
+  })
+  offset: number;
+
+  @ApiProperty({
+    example: '10',
+  })
+  total: number;
 }

--- a/src/noticias/noticia.entity.ts
+++ b/src/noticias/noticia.entity.ts
@@ -26,7 +26,7 @@ export class Noticia {
   @Column({ unique: true })
   slug: string;
 
-  @OneToOne(() => Noticia, (noticia) => noticia.id, {
+  @OneToOne(() => Asset, (asset) => asset.id, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'noticiaThumb' })

--- a/src/noticias/noticias.controller.ts
+++ b/src/noticias/noticias.controller.ts
@@ -28,6 +28,7 @@ import {
   DeleteResultResponseDto,
   UpdateResultResponseDto,
 } from 'src/config/responses-dto';
+import { QueriesNoticesDto } from './dto/queries-notices.dto';
 
 @ApiTags('Noticias')
 @Controller('noticias')
@@ -55,8 +56,8 @@ export class NoticiasController {
     description: 'No se encontraron noticias',
     type: NoticiasNotFoundResponseDto,
   })
-  findAll(@Query('limit') limit = 100) {
-    return this.noticiasService.findAll(+limit);
+  findAll(@Query() queries: QueriesNoticesDto) {
+    return this.noticiasService.findAll(queries);
   }
 
   /**
@@ -78,31 +79,6 @@ export class NoticiasController {
   create(@Body() noticiaFields: CreateNoticiaDto, @Request() req: any) {
     const autor = req.user;
     return this.noticiasService.create(autor.id, noticiaFields);
-  }
-
-  /**
-   * Endpoint para obtener las noticias de un autor
-   * @param autor El id del autor
-   * @returns Las noticias del autor
-   */
-  @ApiOperation({
-    summary: 'Obtener las noticias de un autor',
-    description: 'Obtiene todas las noticias hechas por un autor',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Lista de noticias',
-    type: [Noticia],
-  })
-  @ApiResponse({
-    status: 404,
-    description: 'No se encontraron noticias',
-    type: NoticiasNotFoundResponseDto,
-  })
-  @Get('autor/:autor')
-  @Roles(Role.ADMINISTRATOR, Role.DEVELOPER)
-  findByAutor(@Param('autor') autor: number) {
-    return this.noticiasService.findByAutor(autor);
   }
 
   /**

--- a/src/noticias/noticias.controller.ts
+++ b/src/noticias/noticias.controller.ts
@@ -21,6 +21,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { Role } from '../config/enums/roles.enum';
 import { Noticia } from './noticia.entity';
 import {
+  NoticiaFoundResponseDto,
   NoticiaNotFoundResponseDto,
   NoticiasNotFoundResponseDto,
 } from './dto/responses-dto';
@@ -37,8 +38,11 @@ export class NoticiasController {
   constructor(private noticiasService: NoticiasService) {}
 
   /**
-   * @param limit El número de noticias a devolver
-   * @returns La lista de noticias
+   
+   * @method findAll
+   * @description Obtiene todas las noticias de la base de datos.
+   * @param {QueriesNoticesDto} queries - Parámetros de consulta para filtrar y ordenar las noticias.
+   * @returns {Promise<Noticia[]>} Lista de noticias.
    */
   @Get()
   @Public()
@@ -49,7 +53,15 @@ export class NoticiasController {
   @ApiResponse({
     status: 200,
     description: 'Lista de noticias',
-    type: [Noticia],
+    type: NoticiaFoundResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid order value. Allowed values are ASC or DESC.',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid orderBy value. Allowed values are titulo or fecha.',
   })
   @ApiResponse({
     status: 404,

--- a/src/noticias/noticias.service.ts
+++ b/src/noticias/noticias.service.ts
@@ -6,6 +6,7 @@ import { Noticia } from './noticia.entity';
 import { Repository } from 'typeorm';
 import { UsersService } from '../users/services/users.service';
 import slugify from 'slugify';
+import { QueriesNoticesDto } from './dto/queries-notices.dto';
 
 @Injectable()
 export class NoticiasService {
@@ -52,19 +53,54 @@ export class NoticiasService {
    * @returns The list of noticias
    * @throws {HttpException} if there are no noticias
    */
-  async findAll(limit: number | undefined) {
-    const noticias = await this.noticiasRepository
+  async findAll(queries: QueriesNoticesDto) {
+    const {
+      order = 'ASC',
+      orderBy = 'titulo',
+      offset = 0,
+      limit = null,
+      autor = null,
+    } = queries;
+
+    if (!['ASC', 'DESC'].includes(order.toUpperCase())) {
+      throw new HttpException(
+        'Invalid order value. Allowed values are ASC or DESC.',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (!['titulo', 'fecha'].includes(orderBy)) {
+      throw new HttpException(
+        'Invalid orderBy value. Allowed values are titulo or fecha.',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const queryBuilder = this.noticiasRepository
       .createQueryBuilder('noticia')
       .leftJoinAndSelect('noticia.thumb', 'thumb')
-      .addOrderBy('noticia.fecha', 'DESC')
-      .take(limit)
-      .getMany();
+
+      .orderBy(`noticia.${orderBy}`, order.toUpperCase() as 'ASC' | 'DESC')
+      .skip(offset);
+
+    if (autor !== null) {
+      queryBuilder.andWhere('noticia.autor = :autor', { autor });
+    }
+
+    if (limit !== null) {
+      queryBuilder.take(limit);
+    }
+
+    const [noticias, total] = await queryBuilder.getManyAndCount();
 
     if (!noticias.length) {
       throw new HttpException('No noticias found', HttpStatus.NOT_FOUND);
     }
 
-    return noticias;
+    return {
+      items: noticias,
+      offset,
+      total,
+    };
   }
 
   /**
@@ -83,27 +119,6 @@ export class NoticiasService {
       throw new HttpException('Noticia not found', HttpStatus.NOT_FOUND);
     }
     return noticia;
-  }
-
-  /**
-   * Get noticias by autor
-   * @param autor The id of the autor
-   * @returns The noticias by the given autor
-   * @throws {HttpException} if there are no noticias
-   */
-  async findByAutor(autor: number) {
-    const noticias = await this.noticiasRepository
-      .createQueryBuilder('noticia')
-      .leftJoinAndSelect('noticia.autor', 'autor')
-      .leftJoinAndSelect('noticia.thumb', 'thumb')
-      .where('autor.id = :autor', { autor })
-      .getMany();
-
-    if (!noticias.length) {
-      throw new HttpException('No noticias found', HttpStatus.NOT_FOUND);
-    }
-
-    return noticias;
   }
 
   /**

--- a/src/noticias/noticias.service.ts
+++ b/src/noticias/noticias.service.ts
@@ -7,6 +7,8 @@ import { Repository } from 'typeorm';
 import { UsersService } from '../users/services/users.service';
 import slugify from 'slugify';
 import { QueriesNoticesDto } from './dto/queries-notices.dto';
+import { Order } from 'src/config/enums/order.enum';
+import { OrderBy } from 'src/config/enums/orderby.enum';
 
 @Injectable()
 export class NoticiasService {
@@ -48,28 +50,38 @@ export class NoticiasService {
   }
 
   /**
-   * Get all noticias
-   * @param limit - The number of noticias to return
-   * @returns The list of noticias
-   * @throws {HttpException} if there are no noticias
+   * Retrieves a list of noticias (news) based on the provided query parameters.
+   *
+   * @param queries - An object containing the query parameters for filtering and sorting the noticias.
+   * @param queries.order - The order in which to sort the noticias. Allowed values are 'ASC' or 'DESC'. Defaults to 'ASC'.
+   * @param queries.orderBy - The field by which to sort the noticias. Allowed values are 'titulo' or 'fecha'. Defaults to 'titulo'.
+   * @param queries.offset - The page offset for pagination. Defaults to 0.
+   * @param queries.limit - The maximum number of noticias to retrieve per page. If null, retrieves all noticias.
+   * @param queries.autor - The author of the noticias to filter by. If null, no filtering by author is applied.
+   *
+   * @returns An object containing the retrieved noticias, the offset, and the total count of noticias.
+   *
+   * @throws {HttpException} If the `order` value is invalid.
+   * @throws {HttpException} If the `orderBy` value is invalid.
+   * @throws {HttpException} If no noticias are found.
    */
   async findAll(queries: QueriesNoticesDto) {
     const {
-      order = 'ASC',
-      orderBy = 'titulo',
+      order = Order.ASC,
+      orderBy = OrderBy.TITLE,
       offset = 0,
       limit = null,
       autor = null,
     } = queries;
 
-    if (!['ASC', 'DESC'].includes(order.toUpperCase())) {
+    if (!Object.values(Order).includes(order.toUpperCase() as Order)) {
       throw new HttpException(
         'Invalid order value. Allowed values are ASC or DESC.',
         HttpStatus.BAD_REQUEST,
       );
     }
 
-    if (!['titulo', 'fecha'].includes(orderBy)) {
+    if (!Object.values(OrderBy).includes(orderBy.toLowerCase() as OrderBy)) {
       throw new HttpException(
         'Invalid orderBy value. Allowed values are titulo or fecha.',
         HttpStatus.BAD_REQUEST,
@@ -79,15 +91,14 @@ export class NoticiasService {
       .createQueryBuilder('noticia')
       .leftJoinAndSelect('noticia.thumb', 'thumb')
 
-      .orderBy(`noticia.${orderBy}`, order.toUpperCase() as 'ASC' | 'DESC')
-      .skip(offset);
+      .orderBy(`noticia.${orderBy}`, order.toUpperCase() as 'ASC' | 'DESC');
 
     if (autor !== null) {
       queryBuilder.andWhere('noticia.autor = :autor', { autor });
     }
 
     if (limit !== null) {
-      queryBuilder.take(limit);
+      queryBuilder.take(limit).skip(offset * limit);
     }
 
     const [noticias, total] = await queryBuilder.getManyAndCount();
@@ -97,7 +108,7 @@ export class NoticiasService {
     }
 
     return {
-      items: noticias,
+      data: noticias,
       offset,
       total,
     };


### PR DESCRIPTION
This pull request refactors the endpoint for listing noticias to include the following enhancements:

**Sorting:**
Added support for the order query parameter to sort noticias in ascending (ASC) or descending (DESC) order.
Added support for the orderBy query parameter to sort noticias by titulo or fecha.

**Pagination:**
Implemented offset and limit query parameters to enable pagination.

**Response Structure:**
Each item in the response now includes titulo, thumb, descripcion, slug, and fechaCreacion.
The response includes the offset used and the total number of noticias in the database.

**Error Handling:**
Added validation for query parameters with appropriate HTTP exceptions for invalid values.