### PR TITLE
Return download URL after uploading to Firebase

### DIFF
--- a/src/assets/services/firebase.service.ts
+++ b/src/assets/services/firebase.service.ts
@@ -28,7 +28,7 @@ export class FirebaseService {
     );
     try {
       await uploadBytes(fileRef, new Uint8Array(file.buffer));
-      return fileRef.fullPath;
+      return await getDownloadURL(fileRef);
     } catch (error) {
       console.error('Error uploading file to Firebase:', error);
       throw new Error('Error uploading file');


### PR DESCRIPTION
Change the upload function to return the download URL instead of the file path after a successful upload to Firebase.